### PR TITLE
Crypto Coin Candlechart Feature

### DIFF
--- a/api/coinpaprika.py
+++ b/api/coinpaprika.py
@@ -1,0 +1,45 @@
+import json
+import requests
+
+
+class CoinPaprika(object):
+
+    _base_url = 'https://api.coinpaprika.com/v1/'
+
+    response = None
+
+    def __init__(self, base_url=None):
+        if base_url:
+            self._base_url = base_url
+
+    def _request(self, url):
+        try:
+            self.response = requests.get(url)
+            self.response.raise_for_status()
+            return json.loads(self.response.content.decode('utf-8'))
+        except Exception as e:
+            raise e
+
+    def get_list_coins(self):
+        url_data = "coins"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_coin_by_id(self, coin_id):
+        url_data = f"coins/{coin_id}"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_historical_ohlc(self, coin_id, start, **kwargs):
+        url_data = f"coins/{coin_id}/ohlcv/historical?start={start}"
+
+        for key, value in kwargs.items():
+            url_data += f"&{key}={value}"
+
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_global(self):
+        url_data = "global"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_people_by_id(self, person_id):
+        url_data = f"people/{person_id}"
+        return self._request(f"{self._base_url}{url_data}")

--- a/api/cryptocompare.py
+++ b/api/cryptocompare.py
@@ -1,0 +1,52 @@
+import json
+import requests
+
+
+class CryptoCompare(object):
+
+    _base_url = 'https://min-api.cryptocompare.com/data/'
+    _token = None
+
+    response = None
+
+    def __init__(self, base_url=None, token=None):
+        if base_url:
+            self._base_url = base_url
+        if token:
+            self._token = token
+
+    def _request(self, url):
+        try:
+            self.response = requests.get(url)
+            self.response.raise_for_status()
+            return json.loads(self.response.content.decode('utf-8'))
+        except Exception as e:
+            raise e
+
+    def load_key(self, path):
+        with open(path, 'r') as f:
+            self._token = f.readline().strip()
+
+    def get_historical_ohlcv_daily(self, fsym, tsym, limit):
+        url_data = f"histoday?fsym={fsym}&tsym={tsym}&limit={limit}"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_historical_ohlcv_hourly(self, fsym, tsym, limit):
+        url_data = f"histohour?fsym={fsym}&tsym={tsym}&limit={limit}"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_historical_ohlcv_minute(self, fsym, tsym, limit):
+        url_data = f"histominute?fsym={fsym}&tsym={tsym}&limit={limit}"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_coin_general_info(self, fsyms, tsym):
+        url_data = f"coin/generalinfo?fsyms={fsyms}&tsym={tsym}"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_wallet_info(self):
+        url_data = f"wallets/general?api_key={self._token}"
+        return self._request(f"{self._base_url}{url_data}")
+
+    def get_pool_info(self):
+        url_data = f"mining/pools/general?api_key={self._token}"
+        return self._request(f"{self._base_url}{url_data}")

--- a/app/lifeline_crypto_tbot.py
+++ b/app/lifeline_crypto_tbot.py
@@ -16,6 +16,7 @@ from handlers import init_database
 from handlers.base import send_greeting
 from handlers.base import send_welcome
 from handlers.crypto import send_buy_coin
+from handlers.crypto import send_candlechart
 from handlers.crypto import send_chart
 from handlers.crypto import send_coin
 from handlers.crypto import send_coin_address
@@ -64,6 +65,7 @@ def setup_handlers(dp: Dispatcher) -> None:
     dp.register_message_handler(send_coin_address, commands=["coin_address"])
     dp.register_message_handler(send_trending, commands=["trending"])
     dp.register_message_handler(send_chart, commands=["chart"])
+    dp.register_message_handler(send_candlechart, commands=["candle"])
     dp.register_message_handler(send_price_alert, commands=["alert"])
     dp.register_message_handler(send_latest_listings,
                                 commands=["latest_listings"])

--- a/handlers/base.py
+++ b/handlers/base.py
@@ -41,6 +41,7 @@ async def send_welcome(message: Message):
         f"{bold('/sell')}\_{bold('coin')} {italic('ADDRESS')} {italic('PERCENTAGE')}\_{italic('TO')}\_{italic('SELL')} "
         f"to sell coins on PancakeSwap\n\n",
         f"{bold('/chart')} {italic('COIN')} {italic('NUM')}\_{italic('DAYS')} to display coin chart\n\n",
+        f"{bold('/candle')} {italic('COIN')} {italic('NUM')}\_{italic('TIME')} {italic('LETTER')} to display coin candlechart\n\n",
     )
     await message.reply(text=emojize(reply), parse_mode=ParseMode.MARKDOWN)
 

--- a/handlers/crypto.py
+++ b/handlers/crypto.py
@@ -1,13 +1,17 @@
 import asyncio
 import concurrent
 import io
+import time
 from decimal import Decimal
+import dateutil.parser as dau
 from io import BytesIO
+
 
 import aiohttp
 import pandas as pd
 import plotly.graph_objs as go
 import plotly.io as pio
+import plotly.figure_factory as fif
 from aiogram.types import Message
 from aiogram.types import ParseMode
 from aiogram.utils.emoji import emojize
@@ -42,7 +46,11 @@ from config import PANCAKESWAP_FACTORY_ADDRESS
 from config import PANCAKESWAP_ROUTER_ADDRESS
 from config import SELL
 from handlers.base import send_message
+from utils import all_same
 from models import TelegramGroupMember
+from api.coinpaprika import CoinPaprika
+from api.cryptocompare import CryptoCompare
+
 
 HEADERS = {
     "User-Agent":
@@ -669,3 +677,198 @@ async def send_chart(message: Message):
                 BytesIO(pio.to_image(fig, format="jpeg", engine="kaleido"))),
             parse_mode=ParseMode.MARKDOWN,
         )
+    
+
+
+
+async def send_candlechart(message: Message):
+    """Replies to command with coin candlechart for given crypto symbol and amount of time
+
+    Args:
+        message (Message): Message to reply to
+    """
+
+    args = message.get_args().split()
+    reply = ""
+
+    if len(args) != 3:
+        reply = text(
+            f"⚠️ Please provide a valid crypto symbol and time followed by desired timeframe letter:\n"
+            f" m - Minute\n h - Hour\n d - Day\n \n{bold('/candle')} {italic('SYMBOL')} "
+            f"{italic('NUMBER')} {italic('LETTER')}"
+        )
+    else:
+
+
+        base_coin = "USD"
+        symbol = args[0].upper()
+        time_frame = args[1]
+        res = args[2].lower()
+
+
+        # Time frame
+        if len(args) > 1:
+            if res == 'm':
+                resolution = "MINUTE"
+            elif res == 'h':
+                resolution = "HOUR"
+            else:
+                resolution = "DAY"
+        logger.info("Searching for coin historical data for candlechart")
+        if resolution == "MINUTE":
+            ohlcv = CryptoCompare().get_historical_ohlcv_minute(
+                symbol,
+                base_coin,
+                time_frame)
+        elif resolution == "HOUR":
+            ohlcv = CryptoCompare().get_historical_ohlcv_hourly(
+                symbol,
+                base_coin,
+                time_frame)
+        elif resolution == "DAY":
+            ohlcv = CryptoCompare().get_historical_ohlcv_daily(
+                symbol,
+                base_coin,
+                time_frame)
+        else:
+            ohlcv = CryptoCompare().get_historical_ohlcv_hourly(
+                symbol,
+                base_coin,
+                time_frame)
+
+
+        if ohlcv["Response"] == "Error":
+            if ohlcv["Message"] == "limit is larger than max value.":
+                reply=text(f" Time frame can't be larger than {bold('2000')} DAYS data points")
+
+            else:
+                reply = text(f"Error: {ohlcv['Message']}")
+        else:
+                
+            ohlcv = ohlcv["Data"]
+
+            if ohlcv:
+                o = [value["open"] for value in ohlcv]
+                h = [value["high"] for value in ohlcv]
+                l = [value["low"] for value in ohlcv]
+                c = [value["close"] for value in ohlcv]
+                t = [value["time"] for value in ohlcv]
+      
+            if not ohlcv or all_same(o, h, l, c):
+                
+                reply =text(f"{symbol} not found on CryptoCompare. Initiated lookup on CoinPaprika."
+                        f" Data may not be as complete as CoinGecko or CMC")
+                await message.reply(text=emojize(reply), parse_mode=ParseMode.MARKDOWN)
+                reply = ''
+
+
+                cp_ohlc = CoinPaprika().get_list_coins()
+                
+                for c in cp_ohlc:
+                    if c["symbol"] == symbol:
+                        
+                        # Current datetime in seconds
+                        t_now = time.time()
+                        # Convert chart time span to seconds
+                        time_frame = int(time_frame) * 24 * 60 * 60
+                        # Start datetime for chart in seconds
+                        t_start = t_now - int(time_frame)
+
+                        ohlcv = CoinPaprika().get_historical_ohlc(
+                            c["id"],
+                            int(t_start),
+                            end=int(t_now),
+                            quote=base_coin.lower(),
+                            limit=366)
+
+                        if ohlcv:
+                            cp_api = True
+                            break
+                        else:
+                            return
+
+
+                o = [value["open"] for value in ohlcv]
+                h = [value["high"] for value in ohlcv]
+                l = [value["low"] for value in ohlcv]
+                c = [value["close"] for value in ohlcv]
+                t = [time.mktime(dau.parse(value["time_close"]).timetuple()) for value in ohlcv]
+
+
+            margin_l = 140
+            tickformat = "0.8f"
+
+            max_value = max(h)
+            if max_value > 0.9:
+                if max_value > 999:
+                    margin_l = 120
+                    tickformat = "0,.0f"
+                else:
+                    margin_l = 125
+                    tickformat = "0.2f"
+
+
+            fig = fif.create_candlestick(o, h, l, c, pd.to_datetime(t, unit='s'))
+
+
+            fig['layout']['yaxis'].update(
+                tickformat=tickformat,
+                tickprefix="   ",
+                ticksuffix=f"  ")
+
+            fig['layout'].update(
+                title=dict(
+                    text=symbol,
+                    font=dict(
+                        size=26
+                    )
+                ),
+                yaxis=dict(
+                    title=dict(
+                        text=base_coin,
+                        font=dict(
+                            size=18
+                        )
+                    ),
+                )
+            )
+
+            fig['layout'].update(
+                shapes=[{
+                    "type": "line",
+                    "xref": "paper",
+                    "yref": "y",
+                    "x0": 0,
+                    "x1": 1,
+                    "y0": c[len(c) - 1],
+                    "y1": c[len(c) - 1],
+                    "line": {
+                        "color": "rgb(50, 171, 96)",
+                        "width": 1,
+                        "dash": "dot"
+                    }
+                }])
+
+            fig['layout'].update(
+                paper_bgcolor='rgb(233,233,233)',
+                plot_bgcolor='rgb(233,233,233)',
+                autosize=False,
+                width=800,
+                height=600,
+                margin=go.layout.Margin(
+                    l=margin_l,
+                    r=50,
+                    b=85,
+                    t=100,
+                    pad=4
+                ))
+
+
+    if reply:
+        await message.reply(text=emojize(reply), parse_mode=ParseMode.MARKDOWN)
+    else:
+        logger.info("Exporting chart as image")
+        await message.reply_photo(photo=io.BufferedReader(
+            BytesIO(pio.to_image(fig, format="jpeg", engine="kaleido"))),
+            parse_mode=ParseMode.MARKDOWN)
+                        

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,4 @@
+
+
+def all_same(*items):
+    return True if all(v == items[0] for v in items) else False


### PR DESCRIPTION
Added functionality for candlecharts using CryptoCompare and CoinPaprika as APIs. Arguments are:

/candle _COIN_ _TIME_ _LETTER_

where:

- _COIN_: symbol of cryptocurrency
- _TIME_: number of minutes/hours/days to chart data on
- _LETTER_: defines whether to display data on a minutely, hourly or daily manner ('m', 'h', and 'd' respectively)

Disclaimer: Since I couldn't use CoinGecko or CMC APIs for data, not all coins will be supported and not all data will be available for all coins. Eg. SHIB will only have a couple days worth of data, instead of the whole history. 

In such cases, is better to use regular chart instead, until I can integrate CoinGecko or CMC