### PR TITLE
COIN VS BASECOIN Chart option

### DIFF
--- a/handlers/base.py
+++ b/handlers/base.py
@@ -40,8 +40,8 @@ async def send_welcome(message: Message):
         f"PancakeSwap\n\n",
         f"{bold('/sell')}\_{bold('coin')} {italic('ADDRESS')} {italic('PERCENTAGE')}\_{italic('TO')}\_{italic('SELL')} "
         f"to sell coins on PancakeSwap\n\n",
-        f"{bold('/chart')} {italic('COIN')} {italic('NUM')}\_{italic('DAYS')} to display coin chart\n\n",
-        f"{bold('/candle')} {italic('COIN')} {italic('NUM')}\_{italic('TIME')} {italic('LETTER')} to display coin candlechart\n\n",
+        f"{bold('/chart')} {italic('COIN')}-{italic('BASECOIN')} {italic('NUM')}\_{italic('DAYS')} to display coin chart. If BaseCoin not specified, will default to USD\n\n",
+        f"{bold('/candle')} {italic('COIN')}-{italic('BASECOIN')} {italic('NUM')}\_{italic('TIME')} {italic('LETTER')} to display coin candlechart. If BaseCoin not specified, will default to USD\n\n",
     )
     await message.reply(text=emojize(reply), parse_mode=ParseMode.MARKDOWN)
 


### PR DESCRIPTION
Added option to utilize a base coin when comparing data for charts, instead of always using USD. Basecoin is optional, so when it is not used, chart will default comparing to USD.
Fixes #94 

/chart COIN-BASECOIN NUM_DAYS

/candle COIN-BASECOIN NUM_TIME LETTER