### PR TITLE
Fixed bug where balance misrepresented amount of coins present in wallet

### DIFF
--- a/api/bsc.py
+++ b/api/bsc.py
@@ -78,6 +78,8 @@ class BinanceSmartChain:
 
     @staticmethod
     def get_decimal_representation(quantity, decimals):
+        if decimals < 9:
+            decimals += 2
         return quantity / Decimal(10 ** (18 - (decimals % 18)))
 
     @staticmethod


### PR DESCRIPTION
 Affected coins under 9 decimal places

Closes #172 